### PR TITLE
skip failed text/audio pairs, temporary while debugging audio api calls

### DIFF
--- a/src/app/services/chat.ts
+++ b/src/app/services/chat.ts
@@ -9,13 +9,3 @@ export const generateText = async (messages: ChatMessage[]) => {
   if (!response.ok) throw new Error('Failed to get response');
   return await response.json();
 };
-
-export const generateSpeech = async (text: string) => {
-  const response = await fetch('/api/speech', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ text }),
-  });
-  if (!response.ok) throw new Error('Failed to generate audio');
-  return await response.blob();
-};

--- a/src/app/services/video.ts
+++ b/src/app/services/video.ts
@@ -39,7 +39,7 @@ export const generateVideo = async (text: string) => {
 
   successfulScenes.forEach((result) => {
     formData.append('texts', result.scene);
-    formData.append('audio_files', result.audioBlob!, `scene_${result.index}.mp3`);
+    formData.append('audio_files', result.audioBlob as Blob, `scene_${result.index}.mp3`);
   });
 
   const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/generate-video`, {

--- a/src/app/services/video.ts
+++ b/src/app/services/video.ts
@@ -16,16 +16,30 @@ export const generateVideo = async (text: string) => {
     throw new Error('No scenes found in text');
   }
 
-  // Generate audio for each scene
-  const audioBlobs = await Promise.all(
-    scenes.map(scene => generateSpeech(scene))
+  // Generate audio for each scene and track results
+  const sceneResults = await Promise.all(
+    scenes.map(async (scene, index) => {
+      try {
+        const audioBlob = await generateSpeech(scene);
+        return { success: true, scene, audioBlob, index };
+      } catch (error) {
+        console.error(`Failed to generate audio for scene ${index + 1}:`, error);
+        return { success: false, scene, index };
+      }
+    })
   );
 
-  // Create form data with all scenes and audio files
+  // Filter out failed scenes and create form data with successful ones
   const formData = new FormData();
-  scenes.forEach((scene, i) => {
-    formData.append('texts', scene);
-    formData.append('audio_files', audioBlobs[i], `scene_${i}.mp3`);
+  const successfulScenes = sceneResults.filter((result) => result.success);
+
+  if (successfulScenes.length === 0) {
+    throw new Error('Failed to generate audio for any scenes');
+  }
+
+  successfulScenes.forEach((result) => {
+    formData.append('texts', result.scene);
+    formData.append('audio_files', result.audioBlob!, `scene_${result.index}.mp3`);
   });
 
   const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/generate-video`, {


### PR DESCRIPTION
Also, remove unused duplicate of generateSpeech method.